### PR TITLE
fix: remove tabler-icons for speedup

### DIFF
--- a/bin/admin-panel/view/package.json
+++ b/bin/admin-panel/view/package.json
@@ -40,7 +40,6 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
-    "@tabler/icons-react": "^3.19.0",
     "@tanstack/react-query": "^5.51.21",
     "axios": "^1.7.2",
     "class-variance-authority": "^0.7.0",

--- a/bin/admin-panel/view/pnpm-lock.yaml
+++ b/bin/admin-panel/view/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.1.3
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@tabler/icons-react':
-        specifier: ^3.19.0
-        version: 3.21.0(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.51.21
         version: 5.59.16(react@18.3.1)
@@ -1504,14 +1501,6 @@ packages:
     resolution: {integrity: sha512-HGZgRFFYrMrP3TJlq58nR1xy8zHKId25vhmm5S9jETEfDf6xybPxsavFTJaufe2zgOGYJBskGlj49CwtEuFhWQ==}
     cpu: [x64]
     os: [win32]
-
-  '@tabler/icons-react@3.21.0':
-    resolution: {integrity: sha512-Qq0GnZzzccbv/zuMyXAUUPlogNAqx9KsF8cr/ev3bxs+GMObqNEjXv1eZl9GFzxyQTS435siJNU8A1BaIYhX8g==}
-    peerDependencies:
-      react: '>= 16'
-
-  '@tabler/icons@3.21.0':
-    resolution: {integrity: sha512-5+GkkmWCr1wgMor5cOF1/YYflTQdc15y10FUikJ3HW8hDiFjfbuoAHJi17FT1vwsr1sA78rkJMn+fDoOOjnnPA==}
 
   '@tanstack/query-core@5.59.16':
     resolution: {integrity: sha512-crHn+G3ltqb5JG0oUv6q+PMz1m1YkjpASrXTU+sYWW9pLk0t2GybUHNRqYPZWhxgjPaVGC4yp92gSFEJgYEsPw==}
@@ -4228,13 +4217,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.24.3':
     optional: true
-
-  '@tabler/icons-react@3.21.0(react@18.3.1)':
-    dependencies:
-      '@tabler/icons': 3.21.0
-      react: 18.3.1
-
-  '@tabler/icons@3.21.0': {}
 
   '@tanstack/query-core@5.59.16': {}
 

--- a/bin/admin-panel/view/src/hooks/use-menu.tsx
+++ b/bin/admin-panel/view/src/hooks/use-menu.tsx
@@ -1,4 +1,3 @@
-import { IconBrandDiscord } from '@tabler/icons-react'
 import {
   AlignHorizontalDistributeCenterIcon,
   ArrowLeftRightIcon,
@@ -6,6 +5,7 @@ import {
   ChartPieIcon,
   CreditCardIcon,
   Settings2Icon,
+  UsersIcon
 } from 'lucide-react'
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
@@ -60,7 +60,7 @@ export const useMenu = () => {
       {
         title: 'Discord',
         url: 'https://discord.gg/g5KYHRKS52',
-        icon: IconBrandDiscord,
+        icon: UsersIcon,
       },
     ],
   }


### PR DESCRIPTION
It appears that we have to load the entire tabler-icons package even if we only use a single icon. Temporarily remove it and replace it with an alternative.